### PR TITLE
Added a check for a low clockPin in the _clockCallback method, 

### DIFF
--- a/KY040.py
+++ b/KY040.py
@@ -32,11 +32,12 @@ class KY040:
         GPIO.remove_event_detect(self.switchPin)
     
     def _clockCallback(self, pin):
-        data = GPIO.input(self.dataPin)
-        if data == 1:
-            self.rotaryCallback(self.ANTICLOCKWISE)
-        else:
-            self.rotaryCallback(self.CLOCKWISE)
+        if GPIO.input(self.clockPin) == 0:
+            data = GPIO.input(self.dataPin)
+            if data == 1:
+                self.rotaryCallback(self.ANTICLOCKWISE)
+            else:
+                self.rotaryCallback(self.CLOCKWISE)
 
     def _switchCallback(self, pin):
         if GPIO.input(self.switchPin) == 0:


### PR DESCRIPTION
similar to the _switchCallback method. This lowered the faulty results (i.e., clockwise when turning anti-clockwise and vice versa).
